### PR TITLE
remove shebang from modules

### DIFF
--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -18,7 +18,13 @@ var Dependency = structr({
 
   "content": function(value) {
     if(arguments.length) this._content = value;
-    return this._content || (this._content = fs.readFileSync(this.path, "utf8"));
+    if(this._content == null) {
+      this._content = fs.readFileSync(this.path, "utf8");
+
+      // remove shebang
+      this._content = this._content.replace(/^\#\!.*/, '');
+    }
+    return this._content;
   }
 });
 


### PR DESCRIPTION
A lot of executable node.js modules will start with something like that:

``` javascript
#!/usr/bin/env node
console.log("Hello world!");
```

... with first line indicating that this script should be executed with node. Node.js itself removes shebangs if they're in the beginning of the file, but amdify.js places them in define(...) call resulting in syntax error. That's why they have to be removed manually here.
