### PR TITLE
Mark dependency on 'optimist' in package meta data

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "readmeFilename": "README.md",
   "gitHead": "13fbcf0008418c8bc56cfbde5445438b482834bd",
   "dependencies": {
+    "optimist": "0.6.1",
     "outcome": "0.0.x",
     "flatten": "0.0.x",
     "async": "0.2.x",


### PR DESCRIPTION
Installing and running as shown on this module's home page on npmjs.org throws an error because it depends on a package not listed in the meta data. This should fix that.
